### PR TITLE
Add case_sensitive_email configuration option

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -8,6 +8,7 @@ class Invite < ActiveRecord::Base
   belongs_to :recipient, class_name: Invitation.configuration.user_model_class_name
 
   before_create :generate_token
+  before_save :set_email_case, on: :create
   before_save :check_recipient_existence
 
   validates :email, presence: true
@@ -25,5 +26,11 @@ class Invite < ActiveRecord::Base
   def check_recipient_existence
     recipient = Invitation.configuration.user_model.find_by_email(email)
     self.recipient_id = recipient.id if recipient
+  end
+
+  private
+
+  def set_email_case
+    email.downcase! unless Invitation.configuration.case_sensitive_email
   end
 end

--- a/lib/invitation/configuration.rb
+++ b/lib/invitation/configuration.rb
@@ -45,11 +45,20 @@ module Invitation
     # @return [Boolean]
     attr_accessor :routes
 
+    # Enable or disable email case-sensivity when inviting users.
+    # If set to 'false', searching for user existence via email will disregard case.
+    #
+    # Defaults to 'true'.
+    #
+    # @return [Boolean]
+    attr_accessor :case_sensitive_email
+
     def initialize
       @user_model = ::User if defined?(::User)
       @user_registration_url = ->(params) { Rails.application.routes.url_helpers.sign_up_url(params) }
       @mailer_sender = 'reply@example.com'
       @routes = true
+      @case_sensitive_email = true
     end
 
     def user_model_class_name

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -14,6 +14,21 @@ describe Invite do
       expect(subject.recipient_id).to_not be_nil
       expect(subject.recipient.email).to eq(subject.email)
     end
+
+    context 'case mismatch' do
+      let!(:user) { create(:user) }
+      subject     { create(:invite, email: user.email.upcase) }
+
+      it 'is case-sensitive and does not set recipient by default' do
+        expect(subject.recipient_id).to be_nil
+      end
+
+      it 'sets recipient if case-sensitivity is disabled' do
+        allow(Invitation.configuration).to receive(:case_sensitive_email).and_return(false)
+        expect(subject.recipient_id).to_not be_nil
+        expect(subject.recipient.email).to eq(user.email)
+      end
+    end
   end
 
   context 'recipient is not a user' do


### PR DESCRIPTION
Set via `Invitation.configuration.case_sensitive_email`, this option makes it possible to disable case-sensitivity when inviting users.

Using the default of `true` is the same as the library's implicit behavior, which will _not_ detect existing users if the email case does not match.

Example: a user exists with email `user@example.com`. An invitation is sent to `User@example.com`. By default, this will send the user the "new user" version of the invitation email, when really they should receive the "existing user" version.

Setting this option to `false` will disregard case when checking for existing recipients.