### PR TITLE
Adds note to add invite_token to signup form

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class UsersController < Authenticate::UsersController
   after_action :process_invite_token, only: [:create]
 end
 ``` 
-
+To pass the invite token on signup, add `invite_token` as a hidden field in your signup form.
 
 ## Usage
 


### PR DESCRIPTION
I just implemented the gem and it took a little source diving to realize this was necessary.