### PR TITLE
Add support for Rails 6

### DIFF
--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -14,7 +14,7 @@ class Invite < ActiveRecord::Base
   end
 
   before_create :generate_token
-  before_save :set_email_case, on: :create
+  before_save :set_email_case, if: :email_changed?
   before_save :check_recipient_existence
 
   validates :email, presence: true

--- a/invitation.gemspec
+++ b/invitation.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '>= 4.0', '< 5.3'
+  s.add_dependency 'rails', '>= 4.0', '<= 6.0'
 
   s.add_development_dependency 'factory_girl', '~> 4.8'
   s.add_development_dependency 'rspec-rails', '~> 3.5'


### PR DESCRIPTION
This fixes #27 by adding support for the Rails 6. Validated to work with 6.0.0.rc1 locally.